### PR TITLE
lc_f_e : fix list index out of range for arrf variable

### DIFF
--- a/lc_f_e.py
+++ b/lc_f_e.py
@@ -8,7 +8,10 @@ arrf = json.loads(fun)
 arra = json.loads(arg)
 arre = json.loads(exp)
 
-for i in range(len(fun)-1):
+assert len(arrf) == len(arra)
+assert len(arrf) == len(arre)
+
+for i in range(len(arrf)):
 	t = arrf[i] + '(' + ','.join([str(i) for i in arra[i]]) + ');'
 	if arre[i] is not None:
 		t = 'ret = ' + t + '\nassert(ret==' + str(arre[i]) + ');'


### PR DESCRIPTION
Erroneously, the maximum value for iterating through the arrays was chosen to be the length of the string fun, whereas we need to iterate over each element of the arrays arrf, arra and arre. 